### PR TITLE
Link to jacktrip.github.io instead of jacktrip repo, rename link

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@ maximum-scale=1.0, user-scalable=no" />
     <section id="three-columns-cont" class="three-columns-cont main" style="background-color: #0D2233; max-width: none; margin-bottom: 0; padding-bottom: 75px; padding-top:75px;">
         <div class="three_col">
             <div class="col-cat" id="col01"><img src="images/img_01.jpg" alt="Image of JavaScript computer code on a screen.">
-                <div class="col-title" style="font-weight: 600;">JackTrip Network Music Technology</div>
+                <div class="col-title" style="font-weight: 600;">JackTrip Core</div>
                 <p class="col-p">
                     The JackTrip open source software application enables the live performance of music over the Internet by dramatically reducing the audio latency common in other online collaborations solutions while preserving the original audio quality. It was developed
                     at Stanford University by Professor Chris Chafe and his team and has been in use worldwide since the early 2000's. A large community of advocates and technical contributors continue to make improvements. JackTrip was published under
@@ -329,7 +329,7 @@ maximum-scale=1.0, user-scalable=no" />
                 <p class="col-p">
                     The mission of the JackTrip Foundation is to make high-quality performance of music over the Internet feasible and accessible to everyone. It was formed through a collaboration between Stanford University’s Center for Computer Research in Music and Acoustics
                     (CCRMA) and Silicon Valley software entrepreneurs to alleviate the impact of the Coronavirus pandemic on ensembles and musical arts organizations. The Foundation is dedicated to furthering online musical arts and education by offering
-                    programs for users of the JackTrip Network Music Technology including testing, seminars, partnerships, newsletters, workshops, educational videos and articles.
+                    programs for users of JackTrip including testing, seminars, partnerships, newsletters, workshops, educational videos and articles.
                     <h4 class="center-text btn-margin" style="margin-top:20px; transform: translate(0, -183px);">
                         <button class="col-btn button inverted">Learn More</button>
                     </h4>
@@ -338,8 +338,7 @@ maximum-scale=1.0, user-scalable=no" />
             <div class="col-cat" id="col03"><img src="images/img_03.jpg" alt="Image of a microphone and computer.">
                 <div class="col-title" style="font-weight: 600;">JackTrip Virtual Studio</div>
                 <p class="col-p">
-                    To make the performance of music over the Internet as easy as possible for a broad audience, we developed a new web application, services and plug-and-play devices that automate the configuration, deployment and management of the JackTrip Network Music
-                    Technology. This hardware and software combination makes it easy for groups of any size to quickly get up and running at minimal cost and effort, without requiring deep technology skills. Virtual Studio is a commercial service operated
+                    To make the performance of music over the Internet as easy as possible for a broad audience, we developed a new web application, services and plug-and-play devices that automate the configuration, deployment and management of JackTrip. This hardware and software combination makes it easy for groups of any size to quickly get up and running at minimal cost and effort, without requiring deep technology skills. Virtual Studio is a commercial service operated
                     by JackTrip Labs, a Delaware public-benefit corporation that is an affiliate of the JackTrip Foundation.
                     <h4 class="center-text btn-margin" style="margin-top:20px; transform: translate(0,  -135px);">
                         <button class="col-btn button inverted">Learn More</button>

--- a/js/index.js
+++ b/js/index.js
@@ -49,7 +49,7 @@ function init() {
     // prodAdBtn02.style.cursor = "pointer";
 
     columnBtn01.onclick = function () {
-        window.open('https://github.com/jacktrip/jacktrip', '_blank');
+        window.open('https://jacktrip.github.io/jacktrip/', '_blank');
         console.log('hit');
     };
 


### PR DESCRIPTION
I also removed references to "The JackTrip Network Music Technology", per discussion during the JT dev meeting on June 8, 2021

Please let me know if this looks OK. Also, I wasn't sure where the links are - it seems they are in `js/index.js`, right?