### PR TITLE
Killing off the term "studio hour" to help simplify pricing concepts

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -137,31 +137,15 @@ maximum-scale=1.0, user-scalable=no" />
                                 Until then, the service is available free for groups of up to hundreds of musicians.
                                 Please contact <a href="mailto:sales@jacktrip.org">sales@jacktrip.org</a> for groups larger than 10.</b></em></p>
 
-            <p class="dark-text ">JackTrip Labs provides access to state-of-the art virtual studios for a fee. 
-				These leverage cutting edge cloud computing technology to deliver the best audio performance possible. </p>
             <p class="dark-text">We offer monthly subscription plans that enable you to only pay for what you use. 
-				We measure this using <b>studio minutes</b> and <b>studio hours</b>, where one <b>studio minute</b> is used when one musician
-				is connected to the studio for one minute. Similarly, one <b>studio hour</b> is used when one musician is connected to the studio 
-				for one hour.</p>
-            <p class="dark-text">For example: with a bank of 100 studio hours, you could have one musician 
-				connect to your studio for 100 hours, or have 100 musicians connected for 1 hour. By charging based on 
-				studio minutes and studio hours, costs are directly related to (a) the size of your group, and (b) 
-				how much time you spend using the service.</p>
-			<p class="dark-text" style="margin-bottom:75px;"><b>The owner of a studio is charged for all musicians
-                that connect to it.</b></p>
-        </div>
-    </section>
+				We measure this using <b>studio minutes</b>, where one <b>studio minute</b> is used when one musician
+				is connected to the studio for one minute. <b>The owner of a studio is charged for all musicians
+          that connect to it.</b></p>
 
-    <section id="price-block-0.5" class="price-block-0 main" style="margin-top:0px; margin-bottom:25px;">
-        <div class="left-side-content title-line">
-            <h3 class="separator dark-text-title mainHead" style="float:left; width:100%; margin-bottom: .2em;">
-                Monthly Subscription Plans</h3>
-            <!-- <div class="line-sep" style="margin-bottom: 30px; margin-bottom: 75px;"></div> -->
-			  <div class="line-sep" style="margin-bottom: 30px;"></div>
-            <p class="italicTxt" style="clear: left; margin-top:15px;">Nonprofit pricing is available for nonprofit charitable
-                organizations in good standing, who meet the full eligibility requirements in your country.
-                Please contact <a href="mailto:sales@jacktrip.org">sales@jacktrip.org</a> to sign-up for nonprofit pricing.</p>
-        </div>
+          <p class="italicTxt" style="clear: left; margin-top:15px;">Nonprofit pricing is available for nonprofit charitable
+            organizations in good standing, who meet the full eligibility requirements in your country.
+            Please contact <a href="mailto:sales@jacktrip.org">sales@jacktrip.org</a> to sign-up for nonprofit pricing.</p>
+      </div>
     </section>
 
     <section id="subscription" class="subscription main" style="margin-top:0; margin-bottom: 75px;">
@@ -170,49 +154,65 @@ maximum-scale=1.0, user-scalable=no" />
                 <div class="sub_title">Free</div>
                 <div class="subPrice" id="c1Txt" style="font-weight: 600;">FREE</div>
                 <div class="mus-hours">Create JackTrip or Jamulus studios for up to <b>5</b> musicians, which automatically expire after <b>30</b> minutes</div>
+                <div class="mus-hours">Live mixing presets only</div>
                 <div class="mus-hours">Connect to studios as much as you like</div>
+                <div class="mus-hours">Community support only</div>
             </div>
             <div class="sub" style="background-color: #3079B5;">
                 <div class="sub_title">Basic</div>
                 <div class="subPrice" id="c2Txt" style="font-weight: 600;">$10 <span class="mus-hours">per month</span></div>
-                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>10</b> musicians; includes up to <b>15</b> studio hours (<b>$0.67</b> per hour per musician)</div>
+                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>10</b> musicians; includes up to <b>900</b> studio minutes (<b>$0.67</b> per hour per musician)</div>
+                <div class="mus-hours">Customizable live mixing using our unique Cloud DSP Engine</div>
                 <div class="mus-hours">Connect to studios as much as you like</div>
+                <div class="mus-hours">Web-based expert support</div>
             </div>
             <div class="sub" style="background-color: #3079B5;">
                 <div class="sub_title">Standard</div>
                 <div class="subPrice" id="c3Txt" style="font-weight: 600;">$25 <span class="mus-hours">per month</div>
-                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>20</b> musicians; includes up to <b>45</b> studio hours (<b>$0.56</b> per hour per musician)</div>
+                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>20</b> musicians; includes up to <b>2,700</b> studio minutes (<b>$0.56</b> per hour per musician)</div>
+                <div class="mus-hours">Customizable live mixing using our unique Cloud DSP Engine</div>
                 <div class="mus-hours">Connect to studios as much as you like</div>
+                <div class="mus-hours">Web-based expert support</div>
             </div>
             <div class="sub" style="background-color: #255F8F;">
                 <div class="sub_title">Premium</div>
                 <div class="subPrice" id="c4Txt" style="font-weight: 600;">$50 <span class="mus-hours">per month</div>
-                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>40</b> musicians; includes up to <b>100</b> studio hours (<b>$0.50</b> per hour per musician)</div>
+                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>40</b> musicians; includes up to <b>6,000</b> studio minutes (<b>$0.50</b> per hour per musician)</div>
+                <div class="mus-hours">Customizable live mixing using our unique Cloud DSP Engine</div>
                 <div class="mus-hours">Connect to studios as much as you like</div>
+                <div class="mus-hours">Web-based expert support</div>
             </div>
             <div class="sub" style="background-color: #255F8F;">
                 <div class="sub_title">Auditorium</div>
                 <div class="subPrice" id="c5Txt" style="font-weight: 600;">$100 <span class="mus-hours">per month</div>
-                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>100</b> musicians; includes up to <b>250</b> studio hours (<b>$0.40</b> per hour per musician)</div>
+                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>100</b> musicians; includes up to <b>15,000</b> studio minutes (<b>$0.40</b> per hour per musician)</div>
+                <div class="mus-hours">Customizable live mixing using our unique Cloud DSP Engine</div>
                 <div class="mus-hours">Connect to studios as much as you like</div>
+                <div class="mus-hours">Web-based expert support</div>
             </div>
             <div class="sub" style="background-color: #255F8F;">
                 <div class="sub_title">Concert Hall</div>
                 <div class="subPrice" id="c6Txt" style="font-weight: 600;">$250 <span class="mus-hours">per month</div>
-                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>240</b> musicians; includes up to <b>700</b> studio hours (<b>$0.36</b> per hour per musician)</div>
+                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>240</b> musicians; includes up to <b>42,000</b> studio minutes (<b>$0.36</b> per hour per musician)</div>
+                <div class="mus-hours">Customizable live mixing using our unique Cloud DSP Engine</div>
                 <div class="mus-hours">Connect to studios as much as you like</div>
+                <div class="mus-hours">Web-based expert support</div>
             </div>
             <div class="sub" style="background-color: #1D4A6F;">
                 <div class="sub_title">Amphitheater</div>
                 <div class="subPrice" id="c7Txt" style="font-weight: 600;">$500 <span class="mus-hours">per month</div>
-                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>480</b> musicians; includes up to <b>1,500</b> studio hours (<b>$0.33</b> per hour per musician)</div>
+                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>480</b> musicians; includes up to <b>90,000</b> studio minutes (<b>$0.33</b> per hour per musician)</div>
+                <div class="mus-hours">Customizable live mixing using our unique Cloud DSP Engine</div>
                 <div class="mus-hours">Connect to studios as much as you like</div>
+                <div class="mus-hours">Web-based expert support</div>
             </div>
             <div class="sub" style="background-color: #1D4A6F;">
                 <div class="sub_title">Stadium</div>
                 <div class="subPrice" id="c8Txt" style="font-weight: 600;">$1000 <span class="mus-hours">per month</div>
-                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>480</b> musicians; includes up to <b>3,500</b> studio hours (<b>$0.29</b> per hour per musician)</div>
+                <div class="mus-hours">Create JackTrip and Jamulus studios for up to <b>480</b> musicians; includes up to <b>210,000</b> studio minutes (<b>$0.29</b> per hour per musician)</div>
+                <div class="mus-hours">Customizable live mixing using our unique Cloud DSP Engine</div>
                 <div class="mus-hours">Connect to studios as much as you like</div>
+                <div class="mus-hours">Web-based expert support</div>
             </div>
         </div>
     </section>

--- a/studio.html
+++ b/studio.html
@@ -370,7 +370,7 @@ maximum-scale=1.0, user-scalable=no" />
             <p class="light-text font-400 txt-block-studio">
                 While our bridge devices offer the most streamlined experience and lowest delay,
                 you can now also connect using the free
-                <a href="https://community.jacktrip.org/t/downloading-jacktrip-core/82/11" target="_blank">JackTrip Core desktop application</a>
+                <a href="https://community.jacktrip.org/t/downloading-jacktrip-core/82" target="_blank">JackTrip Core desktop application</a>
                 which is available for Windows, Mac OS X and Linux.
             </p>
 


### PR DESCRIPTION
Fixed studio page link for JackTrip core to not point at removed comments

TODO @codedoser : adjust card heights so that they don't truncate content, and move paragraph about nonprofit pricing below list of plans.